### PR TITLE
Add ability to omit prefix from docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2022-12-06
+
+### Added
+
+- Added `shouldOmitPrefixInDocs` option to config to omit the path prefix in the docs
+
 ## [2.0.0] - 2021-10-02
 
 ### Breaking

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "no-hassle",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -65,6 +65,14 @@ export interface IDocsOptions {
   tags?: string[];
   description?: string;
   summary?: string;
+  /**
+   * The prefix to add to the route path.
+   */
+  prefix?: string;
+  /**
+   * Whether to omit the URL prefix from the generated documentation.
+   */
+  shouldOmitPrefixInDocs?: boolean;
 }
 
 export interface ITemplateRoute extends IDocsOptions {
@@ -73,10 +81,18 @@ export interface ITemplateRoute extends IDocsOptions {
 }
 
 export interface IExecOptions extends IDocsOptions {
+  /**
+   * Whether to generate documentation for this route.
+   */
   docs?: boolean;
+  /**
+   * The HTTP method of the route.
+   */
   method: HttpMethod;
+  /**
+   * The path of the route.
+   */
   path: string;
-  prefix?: string;
 }
 
 export interface IOptions extends IDocsOptions {

--- a/src/swagger/get.ts
+++ b/src/swagger/get.ts
@@ -27,7 +27,6 @@ const globalSwagger: ISwaggerDefinition = {
 export const updateSwagger = (key: string, values: object) =>
   Object.assign(globalSwagger[key], values);
 
-
 const getPath = (path: string, prefix: string, shouldOmitPrefix: boolean) => {
   const cleanedPath = cleanPath(path);
 

--- a/src/swagger/get.ts
+++ b/src/swagger/get.ts
@@ -27,6 +27,18 @@ const globalSwagger: ISwaggerDefinition = {
 export const updateSwagger = (key: string, values: object) =>
   Object.assign(globalSwagger[key], values);
 
+
+const getPath = (path: string, prefix: string, shouldOmitPrefix: boolean) => {
+  const cleanedPath = cleanPath(path);
+
+  if (shouldOmitPrefix) {
+    const prefixRegex = new RegExp(`^${prefix}`);
+    return cleanedPath.replace(prefixRegex, '');
+  }
+
+  return cleanedPath;
+};
+
 export const generateSwagger = (path: string, method: HttpMethod, options: IDocsOptions) => {
   const {
     input,
@@ -35,9 +47,11 @@ export const generateSwagger = (path: string, method: HttpMethod, options: IDocs
     summary,
     description,
     tags = [],
+    shouldOmitPrefixInDocs = false,
+    prefix = '',
   } = options;
 
-  const cleanedPath = cleanPath(path);
+  const cleanedPath = getPath(path, prefix, shouldOmitPrefixInDocs);
 
   const result = {
     [method]: {


### PR DESCRIPTION
We have a use-case where an endpoint is hosted at `<my_service>/public`, but it's accessed through `<api_service>/<prefix>`. We're setting `<api_service>/<prefix>` as the host. But we'd like to remove the `/public` path prefix from the docs